### PR TITLE
Adding intermediate netcdf file action

### DIFF
--- a/src/PseudoNetCDF/core/_variables.py
+++ b/src/PseudoNetCDF/core/_variables.py
@@ -269,10 +269,15 @@ class PseudoNetCDFMaskedVariable(PseudoNetCDFVariable, np.ma.MaskedArray):
                 if not isinstance(dim, int):
                     dim = len(dim)
                 shape.append(dim)
-
+            fill_value = kwds.get('fill_value', None)
+            if fill_value is None:
+                for pk in ('fill_value', 'missing_value', '_FillValue'):
+                    fill_value = kwds.get(pk, None)
+                    if fill_value is not None:
+                        break
             result = np.ma.zeros(shape, dtype='S1' if typecode ==
                                  'c' else typecode,
-                                 fill_value=kwds.get('fill_value', None))
+                                 fill_value=fill_value)
 
         result = result.view(subtype)
         result._ncattrs = ()
@@ -332,7 +337,7 @@ class PseudoNetCDFMaskedVariable(PseudoNetCDFVariable, np.ma.MaskedArray):
         Set attributes (aka properties) and identify user-defined attributes.
         """
         if k[:1] != '_' and \
-           k not in ('dimensions', 'typecode'):
+           k not in ('dimensions', 'typecode', 'mask'):
             if k not in self._ncattrs:
                 self._ncattrs += (k, )
         np.ma.MaskedArray.__setattr__(self, k, v)

--- a/src/PseudoNetCDF/pncgen.py
+++ b/src/PseudoNetCDF/pncgen.py
@@ -135,7 +135,8 @@ class Pseudo2NetCDF:
         self.addVariableProperties(pvar, nvar)
         if data:
             self.addVariableData(pfile, nfile, k)
-        nfile.sync()
+            nfile.sync()
+
         try:
             nfile.flush()
         except Exception:
@@ -162,7 +163,10 @@ class Pseudo2NetCDF:
             if self.verbose:
                 print("Defining", k, file=sys.stdout)
             self.addVariable(pfile, nfile, k, data=self.datafirst)
-        nfile.sync()
+
+        if self.datafirst:
+            nfile.sync()
+
         if not self.datafirst:
             for k in pfile.variables.keys():
                 if self.verbose:


### PR DESCRIPTION
This helps when a file is too big to work in memory. Any operations will
create a file on disk rather than in memory.

Originally designed for new mask function that is also included.