### PR TITLE
Adding ioapi latlon grid support

### DIFF
--- a/src/PseudoNetCDF/conventions/ioapi/_ioapi.py
+++ b/src/PseudoNetCDF/conventions/ioapi/_ioapi.py
@@ -182,7 +182,8 @@ def getmapdef(ifileo, add=True):
         mapdef = PseudoNetCDFVariable(ifileo, gridname, 'i', ())
     mapdef.grid_mapping_name = gridname
     if mapdef.grid_mapping_name == "latitude_longitude":
-        pass
+        mapdef.latitude_of_projection_origin = ifileo.YORIG
+        mapdef.longitude_of_central_meridian = ifileo.XORIG
     elif mapdef.grid_mapping_name == "polar_stereographic":
         mapdef.latitude_of_projection_origin = ifileo.P_ALP * 90
         mapdef.straight_vertical_longitude_from_pole = ifileo.P_GAM


### PR DESCRIPTION
Using the eqc with to_meter keyword set to radians to allow calcualtion of i/j
from lon/lat. Pure lat/lon grids can be translated to regular degree grid spacing via eqc.