### PR TITLE
Units handling for ICARTT independent variable

### DIFF
--- a/src/PseudoNetCDF/icarttfiles/ffi1001.py
+++ b/src/PseudoNetCDF/icarttfiles/ffi1001.py
@@ -180,11 +180,15 @@ Returns:
                 elif (li > SPECIAL_COMMENT_COUNT_LINE and
                       li <= LAST_SPECIAL_COMMENT_LINE):
                     colon_pos = line.find(':')
-                    if line[:1] == ' ':
+                    if (li==(SPECIAL_COMMENT_COUNT_LINE+1) and colon_pos==-1):
+                        k = 'SPECIAL_COMMENTS'
+                        v = line.strip()
+                    elif (line[:1] == ' ' or colon_pos==-1):
+                        # Append to prior attribute line
                         k = lastattr
-                        v = getattr(self, k, '') + line
+                        v = getattr(self, k, '') + line.rstrip()
                     else:
-                        k = line[:colon_pos].strip()
+                        k = line[:colon_pos].strip().replace('/','_')
                         v = line[colon_pos + 1:].strip()
                     setattr(self, k, v)
                     lastattr = k

--- a/src/PseudoNetCDF/icarttfiles/ffi1001.py
+++ b/src/PseudoNetCDF/icarttfiles/ffi1001.py
@@ -146,8 +146,16 @@ Returns:
                     self.TIME_INTERVAL = line.strip()
                 elif li == UNIT_LINE:
                     unitstr = line.replace('\n', '').replace('\r', '').strip()
-                    units.append(unitstr)
-                    self.INDEPENDENT_VARIABLE = units[-1]
+                    self.INDEPENDENT_VARIABLE_DEFINITION = unitstr
+                    unitstr = [s.strip() for s in unitstr.split(',')]
+                    self.INDEPENDENT_VARIABLE = unitstr[0]
+                    nstr = len(unitstr)
+                    if nstr==1:
+                        units.append(unitstr[0])
+                        self.INDEPENDENT_VARIABLE_UNITS = unitstr[0]
+                    if nstr>=2:
+                        units.append(unitstr[1])
+                        self.INDEPENDENT_VARIABLE_UNITS = unitstr[1]
                 elif li == SCALE_LINE:
                     scales = [eval(i) for i in split(line)]
                 elif li == MISSING_LINE:


### PR DESCRIPTION
In version 2 of the ICARTT file format standards,
the independent variable is specified as:
Variable short name, variable unit, variable standard name, [optional variable long name]

In version 1, the defining the units alone was permitted.

For lines that split on ',' (i.e. version 2)
the variable name and units are both used.

Signed-off-by: Christopher Holmes <cdholmes@fsu.edu>