### PR TITLE
Updated non .py scripts to be deprecated copies of the .py versions

### DIFF
--- a/scripts/pncdump
+++ b/scripts/pncdump
@@ -1,2 +1,7 @@
-#!/usr/bin/env bash
-python -um PseudoNetCDF.pncdump "$@"
+#!/usr/bin/env python
+from PseudoNetCDF.pncdump import main
+import warnings
+
+
+warnings.warn('pncdump is deprecated; use pncdump.py', DeprecationWarning)
+main()

--- a/scripts/pncdump.py
+++ b/scripts/pncdump.py
@@ -1,3 +1,3 @@
-#!/usr/bin/env python -u
+#!/usr/bin/env python
 from PseudoNetCDF.pncdump import main
 main()

--- a/scripts/pnceval
+++ b/scripts/pnceval
@@ -1,2 +1,7 @@
-#!/usr/bin/env bash
-python -m PseudoNetCDF.pnceval "$@"
+#!/usr/bin/env python
+from PseudoNetCDF.pnceval import main
+import warnings
+
+
+warnings.warn('pnceval is deprecated; use pnceval.py', DeprecationWarning)
+main()

--- a/scripts/pncgen
+++ b/scripts/pncgen
@@ -1,2 +1,7 @@
-#!/usr/bin/env bash
-python -m PseudoNetCDF.pncgen "$@"
+#!/usr/bin/env python
+from PseudoNetCDF.pncgen import main
+import warnings
+
+
+warnings.warn('pncgen is deprecated; use pncgen.py', DeprecationWarning)
+main()

--- a/scripts/pncload
+++ b/scripts/pncload
@@ -1,2 +1,7 @@
-#!/usr/bin/env bash
-python -um PseudoNetCDF.pncload "$@"
+#!/usr/bin/env python
+from PseudoNetCDF.pncload import main
+import warnings
+
+
+warnings.warn('pncload is deprecated; use pncload.py', DeprecationWarning)
+main()

--- a/scripts/pncview
+++ b/scripts/pncview
@@ -1,2 +1,7 @@
-#!/usr/bin/env bash
-python -um PseudoNetCDF.pncview "$@"
+#!/usr/bin/env python
+from PseudoNetCDF.pncview import main
+import warnings
+
+
+warnings.warn('pncview is deprecated; use pncview.py', DeprecationWarning)
+main()


### PR DESCRIPTION
By deprecating bash scripts, better uniformity across platforms will be acheived. There is no functionality change.