### PR TITLE
Enhancement/disable colorbar map

### DIFF
--- a/src/PseudoNetCDF/ArrayTransforms.py
+++ b/src/PseudoNetCDF/ArrayTransforms.py
@@ -147,62 +147,62 @@ class TestInteriorVertex(unittest.TestCase):
         pass
 
     def test2D2DSum(self):
-        self.assert_((interior_vertex_func(
+        self.assertTrue((interior_vertex_func(
             self.A2D, dims=(-1, -2), func=sum) == self.sum2D).all())
 
     def test2D2DMean(self):
-        self.assert_((interior_vertex_func(
+        self.assertTrue((interior_vertex_func(
             self.A2D, dims=(-1, -2), func=mean) == self.mean2D).all())
 
     def test3D2DSum(self):
         newv = interior_vertex_func(self.A3D, dims=(-1, -2), func=sum)
         checkv = self.sum2D.reshape(1, 3, 3)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test3D2DMean(self):
         newv = interior_vertex_func(self.A3D, dims=(-1, -2), func=mean)
         checkv = self.mean2D.reshape(1, 3, 3)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test3D3DSum(self):
         newv = interior_vertex_func(self.A3D, dims=(-1, -2, -3), func=sum)
         checkv = (self.sum2D.reshape(1, 3, 3) * 2)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test3D3DMean(self):
         newv = interior_vertex_func(self.A3D, dims=(-1, -2, -3), func=mean)
         checkv = self.mean2D.reshape(1, 3, 3)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test4D2DSum(self):
         newv = interior_vertex_func(self.A4D, dims=(-1, -2), func=sum)
         checkv = self.sum2D.reshape(1, 1, 3, 3)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test4D2DMean(self):
         newv = interior_vertex_func(self.A4D, dims=(-1, -2), func=mean)
         checkv = self.mean2D.reshape(1, 1, 3, 3)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test4D3DSum(self):
         newv = interior_vertex_func(self.A4D, dims=(-1, -2, -3), func=sum)
         checkv = self.sum2D.reshape(1, 1, 3, 3) * 2
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test4D3DMean(self):
         newv = interior_vertex_func(self.A4D, dims=(-1, -2, -3), func=mean)
         checkv = self.mean2D.reshape(1, 1, 3, 3)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test4D4DSum(self):
         newv = interior_vertex_func(self.A4D, dims=(-1, -2, -3, -4), func=sum)
         checkv = (self.sum2D.reshape(1, 1, 3, 3) * 4)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
     def test4D4DMean(self):
         newv = interior_vertex_func(self.A4D, dims=(-1, -2, -3, -4), func=mean)
         checkv = self.mean2D.reshape(1, 1, 3, 3)
-        self.assert_((newv == checkv).all())
+        self.assertTrue((newv == checkv).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/ArrayTransforms.py
+++ b/src/PseudoNetCDF/ArrayTransforms.py
@@ -34,8 +34,8 @@ def interior_vertex_func(a, dims=(-1, -2), func=sum):
         one_to_end = full_shape.copy()
         zero_to_minus_one[dim] = slice(0, -1)
         one_to_end[dim] = slice(1, None)
-        out_array = func(array([out_array[zero_to_minus_one.tolist()],
-                                out_array[one_to_end.tolist()]]), 0)
+        out_array = func(array([out_array[tuple(zero_to_minus_one.tolist())],
+                                out_array[tuple(one_to_end.tolist())]]), 0)
 
     return out_array
 

--- a/src/PseudoNetCDF/camxfiles/ArrayTransforms.py
+++ b/src/PseudoNetCDF/camxfiles/ArrayTransforms.py
@@ -209,52 +209,52 @@ class TestInteriorVertex(unittest.TestCase):
 
     def test2D2DSum(self):
         testv = interior_vertex_func(self.A2D, dims=(-1, -2), func=sum)
-        self.assert_((testv == self.sum2D).all())
+        self.assertTrue((testv == self.sum2D).all())
 
     def test2D2DMean(self):
         testv = interior_vertex_func(self.A2D, dims=(-1, -2), func=mean)
-        self.assert_((testv == self.mean2D).all())
+        self.assertTrue((testv == self.mean2D).all())
 
     def test3D2DSum(self):
         testv = interior_vertex_func(self.A3D, dims=(-1, -2), func=sum)
-        self.assert_((testv == self.sum2D.reshape(1, 3, 3)).all())
+        self.assertTrue((testv == self.sum2D.reshape(1, 3, 3)).all())
 
     def test3D2DMean(self):
         testv = interior_vertex_func(self.A3D, dims=(-1, -2), func=mean)
-        self.assert_((testv == self.mean2D.reshape(1, 3, 3)).all())
+        self.assertTrue((testv == self.mean2D.reshape(1, 3, 3)).all())
 
     def test3D3DSum(self):
         testv = interior_vertex_func(self.A3D, dims=(-1, -2, -3), func=sum)
-        self.assert_((testv == (self.sum2D.reshape(1, 3, 3) * 2)).all())
+        self.assertTrue((testv == (self.sum2D.reshape(1, 3, 3) * 2)).all())
 
     def test3D3DMean(self):
         testv = interior_vertex_func(self.A3D, dims=(-1, -2, -3), func=mean)
-        self.assert_((testv == self.mean2D.reshape(1, 3, 3)).all())
+        self.assertTrue((testv == self.mean2D.reshape(1, 3, 3)).all())
 
     def test4D2DSum(self):
         testv = interior_vertex_func(self.A4D, dims=(-1, -2), func=sum)
-        self.assert_((testv == self.sum2D.reshape(1, 1, 3, 3)).all())
+        self.assertTrue((testv == self.sum2D.reshape(1, 1, 3, 3)).all())
 
     def test4D2DMean(self):
         testv = interior_vertex_func(self.A4D, dims=(-1, -2), func=mean)
-        self.assert_((testv == self.mean2D.reshape(1, 1, 3, 3)).all())
+        self.assertTrue((testv == self.mean2D.reshape(1, 1, 3, 3)).all())
 
     def test4D3DSum(self):
         testv = interior_vertex_func(self.A4D, dims=(-1, -2, -3), func=sum)
-        self.assert_((testv == (self.sum2D.reshape(1, 1, 3, 3) * 2)).all())
+        self.assertTrue((testv == (self.sum2D.reshape(1, 1, 3, 3) * 2)).all())
 
     def test4D3DMean(self):
         testv = interior_vertex_func(self.A4D, dims=(-1, -2, -3), func=mean)
-        self.assert_((testv == self.mean2D.reshape(1, 1, 3, 3)).all())
+        self.assertTrue((testv == self.mean2D.reshape(1, 1, 3, 3)).all())
 
     def test4D4DSum(self):
         testv = interior_vertex_func(self.A4D, dims=(-1, -2, -3, -4), func=sum)
-        self.assert_((testv == (self.sum2D.reshape(1, 1, 3, 3) * 4)).all())
+        self.assertTrue((testv == (self.sum2D.reshape(1, 1, 3, 3) * 4)).all())
 
     def test4D4DMean(self):
         testv = interior_vertex_func(self.A4D, dims=(-1, -2, -3, -4),
                                      func=mean)
-        self.assert_((testv == self.mean2D.reshape(1, 1, 3, 3)).all())
+        self.assertTrue((testv == self.mean2D.reshape(1, 1, 3, 3)).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/camxfiles/FortranFileUtil.py
+++ b/src/PseudoNetCDF/camxfiles/FortranFileUtil.py
@@ -402,7 +402,7 @@ class TestFileUtils(unittest.TestCase):
         from numpy import arange
         self.tmprf._newrecord(0)
         self.assertTrue((arange(20, dtype='f') ==
-                      self.tmprf.aread('f', 20)).all())
+                        self.tmprf.aread('f', 20)).all())
 
     def testReadInto(self):
         from numpy import arange, zeros
@@ -419,7 +419,7 @@ class TestFileUtils(unittest.TestCase):
         self.tmprf._newrecord(0)
         self.tmprf.next()
         self.assertTrue((arange(20, dtype='i') ==
-                      self.tmprf.aread('i', 20)).all())
+                        self.tmprf.aread('i', 20)).all())
 
     def testSeek(self):
         self.tmprf._newrecord(0)

--- a/src/PseudoNetCDF/camxfiles/FortranFileUtil.py
+++ b/src/PseudoNetCDF/camxfiles/FortranFileUtil.py
@@ -401,7 +401,7 @@ class TestFileUtils(unittest.TestCase):
     def testFloat(self):
         from numpy import arange
         self.tmprf._newrecord(0)
-        self.assert_((arange(20, dtype='f') ==
+        self.assertTrue((arange(20, dtype='f') ==
                       self.tmprf.aread('f', 20)).all())
 
     def testReadInto(self):
@@ -412,13 +412,13 @@ class TestFileUtils(unittest.TestCase):
 
         # Necessary because written to anticipate fortran swapping of axes
         read_into(self.tmprf, dest, '', 'f')
-        self.assert_((arange(20, dtype='f').reshape((4, 5)) == dest).all())
+        self.assertTrue((arange(20, dtype='f').reshape((4, 5)) == dest).all())
 
     def testInt(self):
         from numpy import arange
         self.tmprf._newrecord(0)
         self.tmprf.next()
-        self.assert_((arange(20, dtype='i') ==
+        self.assertTrue((arange(20, dtype='i') ==
                       self.tmprf.aread('i', 20)).all())
 
     def testSeek(self):
@@ -439,7 +439,7 @@ class TestFileUtils(unittest.TestCase):
         self.tmprf.next()
         checkv = array(["The quick brown fox "])
         testv = self.tmprf.aread('S20', 1)
-        self.assert_(np.any(checkv == testv))
+        self.assertTrue(np.any(checkv == testv))
 
     def runTest(self):
         pass

--- a/src/PseudoNetCDF/camxfiles/cloud_rain/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/cloud_rain/Memmap.py
@@ -248,7 +248,7 @@ class TestMemmap(unittest.TestCase):
                         0.00000000e+00, 2.26519203e+01, 4.96763992e+00,
                         0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
                        dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((crfile.variables['COD'] == checkv).all())
+        self.assertTrue((crfile.variables['COD'] == checkv).all())
 
     def testNCF2CR(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/height_pressure/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/height_pressure/Memmap.py
@@ -199,7 +199,7 @@ class TestMemmap(unittest.TestCase):
                         1.04823120e+02, 1.02206909e+02, 1.02940186e+02,
                         1.04224609e+02, 1.04841797e+02, 1.04740723e+02],
                        dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((hpfile.variables['HGHT'] == checkv).all())
+        self.assertTrue((hpfile.variables['HGHT'] == checkv).all())
 
     def testNCF2HP(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/height_pressure/Read.py
+++ b/src/PseudoNetCDF/camxfiles/height_pressure/Read.py
@@ -327,7 +327,7 @@ class TestRead(unittest.TestCase):
                         1.04224609e+02, 1.04841797e+02, 1.04740723e+02],
                        dtype='f').reshape(2, 3, 4, 5)
 
-        self.assert_((hpfile.variables['HGHT'] == checkv).all())
+        self.assertTrue((hpfile.variables['HGHT'] == checkv).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/camxfiles/humidity/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/humidity/Memmap.py
@@ -114,7 +114,7 @@ class TestMemmap(unittest.TestCase):
                         6.97552490e+01, 6.80159912e+01, 6.85028076e+01,
                         6.93570557e+01, 6.97674561e+01, 6.97009277e+01],
                        dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((humfile.variables['HUM'] == checkv).all())
+        self.assertTrue((humfile.variables['HUM'] == checkv).all())
 
     def testNCF2HUM(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/humidity/Read.py
+++ b/src/PseudoNetCDF/camxfiles/humidity/Read.py
@@ -113,7 +113,7 @@ class TestRead(unittest.TestCase):
                         6.97552490e+01, 6.80159912e+01, 6.85028076e+01,
                         6.93570557e+01, 6.97674561e+01, 6.97009277e+01],
                        dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((humfile.variables['HUM'] == checkv).all())
+        self.assertTrue((humfile.variables['HUM'] == checkv).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/camxfiles/one3d/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/one3d/Memmap.py
@@ -208,7 +208,7 @@ class TestMemmap(unittest.TestCase):
                         1.02998519e+00, 1.00000000e+00, 1.00000000e+00,
                         2.60322971e+01, 4.26534195e+01, 4.17046585e+01],
                        dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((vdfile.variables['UNKNOWN'] == checkv).all())
+        self.assertTrue((vdfile.variables['UNKNOWN'] == checkv).all())
 
     def testNCF2KV(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/one3d/Read.py
+++ b/src/PseudoNetCDF/camxfiles/one3d/Read.py
@@ -317,7 +317,7 @@ class TestRead(unittest.TestCase):
                         1.02998519e+00, 1.00000000e+00, 1.00000000e+00,
                         2.60322971e+01, 4.26534195e+01, 4.17046585e+01],
                        dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((vdfile.variables['UNKNOWN'] == checkv).all())
+        self.assertTrue((vdfile.variables['UNKNOWN'] == checkv).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/camxfiles/point_source/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/point_source/Memmap.py
@@ -308,7 +308,7 @@ class TestMemmap(unittest.TestCase):
         emissfile = point_source(
             PseudoNetCDF.testcase.camxfiles_paths['point_source'])
         v = emissfile.variables['NO2']
-        self.assert_((v[:] == np.array(
+        self.assertTrue((v[:] == np.array(
             [0.00000000e+00, 3.12931000e+02, 1.23599997e+01, 0.00000000e+00,
              5.27999992e+01, 0.00000000e+00, 3.12931000e+02, 1.23599997e+01,
              0.00000000e+00, 5.27999992e+01], dtype='f').reshape(2, 5)).all())

--- a/src/PseudoNetCDF/camxfiles/point_source/Read.py
+++ b/src/PseudoNetCDF/camxfiles/point_source/Read.py
@@ -347,7 +347,7 @@ class TestRead(unittest.TestCase):
         emissfile = point_source(
             PseudoNetCDF.testcase.camxfiles_paths['point_source'])
         v = emissfile.variables['NO2']
-        self.assert_((v[:] == array(
+        self.assertTrue((v[:] == array(
             [0.00000000e+00, 3.12931000e+02, 1.23599997e+01, 0.00000000e+00,
              5.27999992e+01, 0.00000000e+00, 3.12931000e+02, 1.23599997e+01,
              0.00000000e+00, 5.27999992e+01], dtype='f').reshape(2, 5)).all())

--- a/src/PseudoNetCDF/camxfiles/point_source/Write.py
+++ b/src/PseudoNetCDF/camxfiles/point_source/Write.py
@@ -133,8 +133,10 @@ def ncf2point_source(ncffile, outpath):
     stk_prop_fmt = np.dtype(dict(
         names=['xstk', 'ystk', 'hstk', 'dstk', 'tstk', 'vstk'],
         formats=['>f', '>f', '>f', '>f', '>f', '>f']))
-    stk_prop = np.ones((1,), dtype=np.dtype(
-        [('SPAD', '>i', 1), ('DATA', stk_prop_fmt, nstk), ('EPAD', '>i', 1)]))
+    stk_prop = np.ones((1,), dtype=np.dtype([
+        ('SPAD', '>i', (1,)), ('DATA', stk_prop_fmt, nstk),
+        ('EPAD', '>i', (1,))
+    ]))
     stk_prop['SPAD'] = stk_prop['EPAD'] = stk_prop.dtype.itemsize - 8
     stk_prop['DATA']['xstk'] = ncffile.variables['XSTK'][:]
     stk_prop['DATA']['ystk'] = ncffile.variables['YSTK'][:]
@@ -162,9 +164,9 @@ def ncf2point_source(ncffile, outpath):
             names=['ione1', 'ione2', 'kcell', 'flow', 'plmht'],
             formats=['>i', '>i', '>i', '>f', '>f']))
         props = np.ones((1,), dtype=np.dtype(
-            [('SPAD', '>i', 1),
-             ('DATA', time_prop_fmt, nstk),
-             ('EPAD', '>i', 1)]))
+            [('SPAD', '>i', (1,)),
+             ('DATA', time_prop_fmt, (nstk,)),
+             ('EPAD', '>i', (1,))]))
         props['SPAD'] = props['EPAD'] = props.dtype.itemsize - 8
         props['DATA']['ione1'] = ncffile.variables['IONE'][di]
         props['DATA']['ione2'] = ncffile.variables['ITWO'][di]

--- a/src/PseudoNetCDF/camxfiles/temperature/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/temperature/Memmap.py
@@ -210,7 +210,7 @@ class TestMemmap(unittest.TestCase):
                          3.06698334e+02, 3.01333618e+02, 3.03411346e+02,
                          3.05317505e+02, 3.06446869e+02,
                          3.05815948e+02], dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((tempfile.variables['AIRTEMP'] == checkat).all())
+        self.assertTrue((tempfile.variables['AIRTEMP'] == checkat).all())
 
     def testNCF2TEMP(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/temperature/Read.py
+++ b/src/PseudoNetCDF/camxfiles/temperature/Read.py
@@ -166,7 +166,6 @@ class temperature(PseudoNetCDFFile):
         while pos < rflen:
             yield pos
             pos += inc
-        raise StopIteration
 
     def __surfmaps(self):
         for pos in self.__surfpos():
@@ -184,7 +183,6 @@ class temperature(PseudoNetCDFFile):
         while pos < rflen:
             yield pos
             pos += inc
-        raise StopIteration
 
     def __airmaps(self):
         for pos in self.__airpos():

--- a/src/PseudoNetCDF/camxfiles/temperature/Read.py
+++ b/src/PseudoNetCDF/camxfiles/temperature/Read.py
@@ -257,7 +257,7 @@ class TestRead(unittest.TestCase):
                           3.05787415e+02, 3.06698334e+02, 3.01333618e+02,
                           3.03411346e+02, 3.05317505e+02, 3.06446869e+02,
                           3.05815948e+02], dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((tempfile.variables['AIRTEMP'] == check_at).all())
+        self.assertTrue((tempfile.variables['AIRTEMP'] == check_at).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/camxfiles/uamiv/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/uamiv/Memmap.py
@@ -362,7 +362,7 @@ class TestMemmap(unittest.TestCase):
 
     def testAvg(self):
         import PseudoNetCDF.testcase
-        self.assert_(uamiv.isMine(
+        self.assertTrue(uamiv.isMine(
             PseudoNetCDF.testcase.camxfiles_paths['uamiv']))
         emissfile = uamiv(PseudoNetCDF.testcase.camxfiles_paths['uamiv'])
         emissfile.variables['TFLAG']
@@ -374,7 +374,7 @@ class TestMemmap(unittest.TestCase):
              3.90250643e-04, 6.18023798e-04, 3.36963218e-04, 0.00000000e+00,
              1.85579920e-04, 1.96825975e-04, 2.16468165e-04, 2.19882189e-04],
             dtype='f').reshape(1, 1, 4, 5)
-        self.assert_((v == checkv).all())
+        self.assertTrue((v == checkv).all())
 
     def testClose(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/uamiv/Read.py
+++ b/src/PseudoNetCDF/camxfiles/uamiv/Read.py
@@ -376,7 +376,7 @@ class TestuamivRead(unittest.TestCase):
         import PseudoNetCDF.testcase
         emissfile = uamiv(PseudoNetCDF.testcase.camxfiles_paths['uamiv'])
         v = emissfile.variables['NO2']
-        self.assert_((v == array(
+        self.assertTrue((v == array(
             [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00,
              0.00000000e+00, 0.00000000e+00, 1.24175494e-04, 2.79196858e-04,
              1.01672206e-03, 4.36782313e-04, 0.00000000e+00, 1.54810550e-04,

--- a/src/PseudoNetCDF/camxfiles/vertical_diffusivity/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/vertical_diffusivity/Memmap.py
@@ -104,7 +104,7 @@ class TestMemmap(unittest.TestCase):
             1.00000000e+00, 1.44422662e+00, 1.02998519e+00, 1.00000000e+00,
             1.00000000e+00, 2.60322971e+01, 4.26534195e+01,
             4.17046585e+01], dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((vdfile.variables['KV'] == checkv).all())
+        self.assertTrue((vdfile.variables['KV'] == checkv).all())
 
     def testNCF2KV(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/vertical_diffusivity/Read.py
+++ b/src/PseudoNetCDF/camxfiles/vertical_diffusivity/Read.py
@@ -103,7 +103,7 @@ class TestRead(unittest.TestCase):
             1.00000000e+00, 1.44422662e+00, 1.02998519e+00, 1.00000000e+00,
             1.00000000e+00, 2.60322971e+01, 4.26534195e+01,
             4.17046585e+01], dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((vdfile.variables['KV'] == checkv).all())
+        self.assertTrue((vdfile.variables['KV'] == checkv).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/camxfiles/wind/Memmap.py
+++ b/src/PseudoNetCDF/camxfiles/wind/Memmap.py
@@ -204,7 +204,7 @@ class TestMemmap(unittest.TestCase):
             -2.60809243e-01, -2.18679833e+00, -3.59082842e+00, 3.77060443e-01,
             -1.05680525e-01, -8.10511589e-01, -1.40993130e+00,
             -1.76300752e+00], dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((wdfile.variables['V'][:] == checkv).all())
+        self.assertTrue((wdfile.variables['V'][:] == checkv).all())
 
     def testNCF2WD(self):
         import PseudoNetCDF.testcase

--- a/src/PseudoNetCDF/camxfiles/wind/Read.py
+++ b/src/PseudoNetCDF/camxfiles/wind/Read.py
@@ -370,7 +370,7 @@ class TestRead(unittest.TestCase):
             -2.60809243e-01, -2.18679833e+00, -3.59082842e+00, 3.77060443e-01,
             -1.05680525e-01, -8.10511589e-01, -1.40993130e+00,
             -1.76300752e+00], dtype='f').reshape(2, 3, 4, 5)
-        self.assert_((wdfile.variables['V'][:] == checkv).all())
+        self.assertTrue((wdfile.variables['V'][:] == checkv).all())
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/core/_files.py
+++ b/src/PseudoNetCDF/core/_files.py
@@ -1788,7 +1788,7 @@ class PseudoNetCDFFile(PseudoNetCDFSelfReg, object):
         outf : PseudoNetCDFFile
             instance with stacked variables and dimension equal to new length
         """
-        from collections import Iterable
+        from collections.abc import Iterable
         outf = self._copywith(props=True, dimensions=False)
         if isinstance(other, Iterable):
             fs = [self] + list(other)

--- a/src/PseudoNetCDF/geoschemfiles/_bpch.py
+++ b/src/PseudoNetCDF/geoschemfiles/_bpch.py
@@ -499,9 +499,15 @@ class bpch_base(PseudoNetCDFFile):
         ax_kw : keywords for the axes to be created
         plot_kw : keywords for the plot (plot, scatter, or pcolormesh) to be
                   created
-        cbar_kw : keywords for the colorbar
-        map_kw : keywords for the getMap routine, which is only used with
-                 plottype='longitude-latitude'
+        cbar_kw : dictionary or bool or None
+            keywords for the colorbar; if True or None, use defaults.
+            If False, do not create a colorbar
+        map_kw : dictionary or bool or None
+            keywords for the getMap routine, which is only used with
+            map capable dimensions (ie, plottype='longitude-latitude')
+            If True or None, use default configuration dict(countries=True,
+            coastlines=True, states=False, counties=False). If False,
+            do not draw a map.
         dimreduction : dimensions not being used in the plot are removed
                        using applyAlongDimensions(dimkey=dimreduction) where
                        each dimenions
@@ -516,10 +522,10 @@ class bpch_base(PseudoNetCDFFile):
         if plot_kw is None:
             plot_kw = {}
 
-        if cbar_kw is None:
+        if cbar_kw is None or cbar_kw is True:
             cbar_kw = {}
 
-        if map_kw is None:
+        if map_kw is None or map_kw is True:
             map_kw = {}
 
         apply2dim = {}
@@ -593,7 +599,8 @@ class bpch_base(PseudoNetCDFFile):
         if dimpos[xkey] < dimpos[ykey]:
             vals = vals.T
         p = ax.pcolormesh(x, y, vals, **plot_kw)
-        ax.figure.colorbar(p, label=varunit, **cbar_kw)
+        if cbar_kw is not False:
+            ax.figure.colorbar(p, label=varunit, **cbar_kw)
         if ykey == 'pressure':
             ax.set_ylim(y.max(), y.min())
         dfmt = plt.matplotlib.dates.AutoDateFormatter(
@@ -604,7 +611,7 @@ class bpch_base(PseudoNetCDFFile):
             ax.xaxis.set_major_formatter(dfmt)
         if ykey == 'time':
             ax.yaxis.set_major_formatter(dfmt)
-        if plottype == 'longitude-latitude':
+        if plottype == 'longitude-latitude' and map_kw is not False:
             try:
                 bmap = myf.getMap(**map_kw)
                 bmap.drawcoastlines(ax=ax)

--- a/src/PseudoNetCDF/noaafiles/_arl.py
+++ b/src/PseudoNetCDF/noaafiles/_arl.py
@@ -861,12 +861,19 @@ class arlpackedbit(PseudoNetCDFFile):
         return basemap_from_proj4(myprojstr, **kwds)
 
     def plot(self, *args, **kwds):
+        """
+        See PseudoNetCDF.PseudoNetCDFFile.plot. For this file,
+        the default plottype is 'x-y'
+        """
         kwds.setdefault('plottype', 'x-y')
         ax = PseudoNetCDFFile.plot(self, *args, **kwds)
         if kwds['plottype'] == 'x-y':
             map_kw = kwds.get('map_kw', None)
-            if map_kw is None:
+            if map_kw is False:
+                return ax
+            elif map_kw is None or map_kw is True:
                 map_kw = {}
+
             try:
                 map_kw = map_kw.copy()
                 coastlines = map_kw.pop('coastlines', True)


### PR DESCRIPTION
This adds the following abilities.

PseudoNetCDFFile.plot supports `cbar_kw` and `map_kw` options `True` and `False`. `False` disables the colorbar or map. This makes it easier to use without features that are not desired. 

Uses cases for disabling maps: 
* One might build an axes with a map and want to add a tileplot on top without redoing the map.
* The map feature can be slow, so disabling may be desirable for quick plotting.

Use cases for disabling colorbar:
* Multipanel figures that share a colorbar do not need to create one for each figure.
* A color bar might be disabled when a qualitative scale is being used without wanting quantitative evaluation.

As a part of this branch, I also added more flexibility in the `plottype` keyword so that it can choose based on available dimensions. And the mapping feature will recognize both longitude-latitude and lon-lat.