### PR TITLE
Enhancement/python3 no r u

### DIFF
--- a/src/PseudoNetCDF/camxfiles/units.py
+++ b/src/PseudoNetCDF/camxfiles/units.py
@@ -12,7 +12,7 @@ _camx_units = {
 
 
 def get_chemparam_names(chemparampath):
-    inlines = open(chemparampath, 'rU').readlines()
+    inlines = open(chemparampath, 'r').readlines()
     startaero = None
     for li, l in enumerate(inlines):
         if l[:14] == "     Gas Spec ":

--- a/src/PseudoNetCDF/icarttfiles/ffi1001.py
+++ b/src/PseudoNetCDF/icarttfiles/ffi1001.py
@@ -63,7 +63,7 @@ Example:
     def isMine(cls, path):
         try:
             ffifmt = openf(
-                path, 'rU', encoding='utf-8').readline().strip()[-4:]
+                path, 'r', encoding='utf-8').readline().strip()[-4:]
             if hasattr(ffifmt, 'decode'):
                 ffifmt = ffifmt.decode()
             testfmt = u'1001'
@@ -92,7 +92,7 @@ Returns:
         """
         lastattr = None
         PseudoNetCDFFile.__init__(self)
-        f = openf(path, 'rU', encoding=encoding)
+        f = openf(path, 'r', encoding=encoding)
         missing = []
         units = []
         line = f.readline()

--- a/src/PseudoNetCDF/toms/level3.py
+++ b/src/PseudoNetCDF/toms/level3.py
@@ -30,7 +30,7 @@ def _groupdict(reo, line):
 def cdtoms(path, outfile=None):
     if outfile is None:
         outfile = PseudoNetCDFFile()
-    inlines = open(path, 'rU').readlines()
+    inlines = open(path, 'r').readlines()
     dayline = inlines[0]
     daygrp = _groupdict(dayre, dayline)
 

--- a/src/PseudoNetCDF/woudcfiles/_woudc.py
+++ b/src/PseudoNetCDF/woudcfiles/_woudc.py
@@ -97,7 +97,7 @@ class woudcsonde(PseudoNetCDFFile):
         if hasattr(path, 'readline'):
             myf = path
         else:
-            myf = open(path, 'rU')
+            myf = open(path, 'r')
 
         meta = ''
         li = 0


### PR DESCRIPTION
Removing the python2-based unified line endings option. Going forward, PseudoNetCDF is a python3 library and does not need to maintain this backward compatibility. 

See issue: #115 