### PR TITLE
Enhancement/ioapitflag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - pip install --no-deps -e .
 
 script:
-  - flake8 --ignore=W605,W504,E741  src/PseudoNetCDF
+  - flake8 --ignore=W605,W503,W504,E741  src/PseudoNetCDF
   - python -O -c "import PseudoNetCDF";
   - python -m PseudoNetCDF.test;
   - pytest src/PseudoNetCDF

--- a/src/PseudoNetCDF/cmaqfiles/_griddesc.py
+++ b/src/PseudoNetCDF/cmaqfiles/_griddesc.py
@@ -58,7 +58,7 @@ class griddesc(ioapi_base):
         self.FTYPE = FTYPE
         self.VGTYP = VGTYP
         self.GDNAM = GDNAM
-        self.VGTOP = VGTOP
+        self.VGTOP = np.float32(VGTOP)
         self.VGLVLS = np.array(VGLVLS, dtype='f')
         self.NLAYS = len(VGLVLS) - 1
         self.UPNAM = 'GRIDDESC'
@@ -123,11 +123,10 @@ class griddesc(ioapi_base):
             )
         self.createVariable(
             'DUMMY', 'f', dims,
-            units='none',
+            units='none'.ljust(16),
             long_name='DUMMY'.ljust(16),
             var_desc='DUMMY'.ljust(80)
         )
-        setattr(self, 'VAR-LIST', 'DUMMY'.ljust(16))
 
         if self._synthvars is None:
             oldkeys = set(self.variables)
@@ -138,6 +137,9 @@ class griddesc(ioapi_base):
         pnc.conventions.ioapi.add_cf_from_ioapi(self)
         if self._synthvars is None:
             self._synthvars = set(self.variables).difference(oldkeys)
+
+        self.updatemeta()
+        self.getVarlist()
 
 
 if __name__ == '__main__':

--- a/src/PseudoNetCDF/cmaqfiles/_ioapi.py
+++ b/src/PseudoNetCDF/cmaqfiles/_ioapi.py
@@ -447,6 +447,8 @@ class ioapi_base(PseudoNetCDFFile):
 
             tvar[:, :, 0] = yyyyjjj[:, None].repeat(tvar.shape[1], 1)
             tvar[:, :, 1] = hhmmss[:, None].repeat(tvar.shape[1], 1)
+            self.SDATE = tvar[0, 0, 0]
+            self.STIME = tvar[0, 0, 1]
         else:
             if len(self.dimensions['VAR']) == 0:
                 return

--- a/src/PseudoNetCDF/cmaqfiles/_ioapi.py
+++ b/src/PseudoNetCDF/cmaqfiles/_ioapi.py
@@ -535,7 +535,7 @@ Varable failures: {var_failed}
             if len(varliststr_old) % 16 == 0:
                 ivars = int(len(varliststr_old) // 16)
                 varlist = [
-                    varliststr_old[ivar*16:ivar*16+16].strip()
+                    varliststr_old[ivar * 16:ivar * 16 + 16].strip()
                     for ivar in range(ivars)
                 ]
             else:

--- a/src/PseudoNetCDF/core/_files.py
+++ b/src/PseudoNetCDF/core/_files.py
@@ -1741,6 +1741,9 @@ class PseudoNetCDFFile(PseudoNetCDFSelfReg, object):
                 return time
         elif 'TFLAG' in self.variables.keys():
             dates = self.variables['TFLAG'][:][:, 0, 0]
+            if (dates == -635).any():
+                warn('Dates of -635 set to 1970001')
+                dates[dates == -635] = 1970001
             times = self.variables['TFLAG'][:][:, 0, 1]
             yyyys = (dates // 1000).astype('i')
             jjj = dates % 1000
@@ -1766,8 +1769,13 @@ class PseudoNetCDFFile(PseudoNetCDFSelfReg, object):
                 out = np.append(out, out[-1] + dt)
         elif hasattr(self, 'SDATE') and hasattr(self, 'STIME') and \
                 hasattr(self, 'TSTEP') and 'TSTEP' in self.dimensions:
+            jdate = self.SDATE
+            if jdate < 1:
+                warn(f'SDATE was {jdate}; using 1970001')
+                jdate = 1970001
+            hhmmss = self.STIME
             refdate = datetime.strptime(
-                '%07d %06d+0000' % (self.SDATE, self.STIME), '%Y%j %H%M%S%z')
+                '%07d %06d+0000' % (jdate, hhmmss), '%Y%j %H%M%S%z')
             tstepstr = '%06d' % self.TSTEP
             timeincr = timedelta(seconds=int(tstepstr[-2:])) + \
                 timedelta(minutes=int(tstepstr[-4:-2])) + \


### PR DESCRIPTION
Adding better time capability and audit functions.

## Time-independent Functionality

The ioapi getTimes function failed when SDATE was set to -635,
which is used sometimes for time independent data. This had
cascading effects on all functions that used getTimes as part
of the meta-data refresh.

This bug-fix essentially updates the file to have a 1970001
SDATE and warns the user. This is far preferable to the previous
work arounds.

## Adding Audit

It is easy to get IOAPI metadata wrong. When you do, it will
still work in netcdf mode, but will fail when being read by
IOAPI. This update adds an audit system. The audit system will
tell you what is wrong, but will not update it. This is useful
for checking products during development to ensure that they
will be CMAQ-ready when they are complete.