### PR TITLE
Fixing insertDimension

### DIFF
--- a/src/PseudoNetCDF/core/_files.py
+++ b/src/PseudoNetCDF/core/_files.py
@@ -892,7 +892,7 @@ class PseudoNetCDFFile(PseudoNetCDFSelfReg, object):
                 var = outf.copyVariable(
                     vv, key=vk, dimensions=ndims, withdata=False)
 
-                var[...] = np.expand_dims(self.variables[vk][...], axis=bi)
+                var[...] = np.expand_dims(vv[...], axis=bi)
         return outf
 
     def reorderDimensions(self, oldorder, neworder, inplace=False):


### PR DESCRIPTION
See issue #120. This allows the inplace update of in-memory files
by copying a variable and using the original variable as the data
sources. The bug version used the new variable as the data source.