### PR TITLE
Extending GRIDDESC Format

### DIFF
--- a/src/PseudoNetCDF/cmaqfiles/_griddesc.py
+++ b/src/PseudoNetCDF/cmaqfiles/_griddesc.py
@@ -1,4 +1,5 @@
 import PseudoNetCDF as pnc
+from PseudoNetCDF.pncwarn import warn
 import os
 import io
 from datetime import datetime
@@ -6,10 +7,10 @@ from collections import OrderedDict
 import numpy as np
 from ._ioapi import ioapi_base
 
-_prjp = ['GDTYP', 'P_ALP', 'P_BET', 'P_GAM', 'XCENT', 'YCENT']
-_grdp = [
+_prjp = ('GDTYP', 'P_ALP', 'P_BET', 'P_GAM', 'XCENT', 'YCENT')
+_grdp = (
     'PRJNAME', 'XORIG', 'YORIG', 'XCELL', 'YCELL', 'NCOLS', 'NROWS', 'NTHIK'
-]
+)
 
 
 class griddesc(ioapi_base):
@@ -30,7 +31,8 @@ class griddesc(ioapi_base):
 """
     def __init__(
         self, path, GDNAM=None, VGLVLS=(1., 0.), VGTOP=5000., FTYPE=1, VGTYP=7,
-        withcf=True, **prop_kw
+        SDATE=-635, STIME=0, TSTEP=0, var_kwds=None, nsteps=1, withcf=True,
+        **prop_kw
     ):
         """
         Arguments
@@ -48,8 +50,20 @@ class griddesc(ioapi_base):
         VGTYP : int
             Determines the units of VGLVLS and VGTOP. (7: WRF sigma-p,
             6: meters asl, for more details see IOAPI documentation)
+        SDATE : int
+            Starting julian date (YYYYJJJ) or -635
+        STIME : int
+            Starting time as HHMMSS
+        TSTEP : int
+            IOAPI time step in HHMMSS
         FTYPE : int
             1 for gridded; 2 for boundary
+        var_kwds: tuple, list, or dict
+            See setdefvars; Defaults to {'DUMMY': {'units': 'unknown'}}
+        nsteps : int
+            Number of time steps to use. Should be coupled with SDATE, STIME,
+            and TSTEP. nsteps > 1 is not compatible with time independent
+            (TSTEP=0) or SDATE=-635
         withcf : bool
             If true, then CF compatible variables that describe dimensions
             and time are added.
@@ -104,48 +118,120 @@ class griddesc(ioapi_base):
         self.CTIME = int(now.strftime('%H%M%S'))
         self.WDATE = self.CDATE
         self.WTIME = self.CTIME
-        self.SDATE = -635
-        self.STIME = 0
-        self.TSTEP = 0
+        self.SDATE = SDATE
+        self.STIME = STIME
+        self.TSTEP = TSTEP
         self._synthvars = None
         # user supplied properties should overwrite
         # defaults above
         for pk, pv in prop_kw.items():
             self.setncattr(pk, pv)
 
-        self.addtime()
+        self.setdefvars(var_kwds)
+        self.addtime(nsteps)
         self.setgrid(withcf=withcf)
         self.updatemeta()
         self.getVarlist()
 
+    def setdefvars(self, var_kwds):
+        """
+        Arguments
+        ---------
+        var_kwds: list, tuple, or dictionary
+            Variables with units or just a list of variables
+        """
+
+        if var_kwds is None:
+            var_kwds = {'DUMMY': {'units': 'unknown'}}
+        elif isinstance(var_kwds, (tuple, list)):
+            var_kwds = {k: 'unknown' for k in var_kwds}
+        elif hasattr(var_kwds, 'items'):
+            pass
+        else:
+            raise TypeError('var_kwds should be a list, tuple, or dictionary')
+
+        self._var_kwds = {}
+        for k, v in var_kwds.items():
+            if isinstance(v, str):
+                self._var_kwds[k] = {'units': v.ljust(16)}
+            elif isinstance(v, dict):
+                self._var_kwds[k] = {_k: _v for _k, _v in v.items()}
+            else:
+                raise TypeError(
+                    'var_kwds should have either str values (units) or a dict'
+                    + ' of all properties'
+                )
+
     def setgrid(self, key=None, withcf=True):
+        """
+        Remakes the file to use the grid specified by key
+
+        Arguments
+        ---------
+        key : str
+            GDNAM to set the grid of the file
+        withcf : bool
+            Passed to adddims
+
+        Returns
+        -------
+        None
+        """
         if key is None:
             if self.GDNAM is None:
-                self.GDNAM = key = list(self._grd)[0]
-            else:
-                key = self.GDNAM
+                self.GDNAM = list(self._grd)[0]
+
+            key = self.GDNAM.strip()
         grd = self._grd[key]
-        prj = self._prj[grd['PRJNAME']]
+        prj = self._prj[grd['PRJNAME'].strip()]
         self.setncatts(prj)
         self.setncatts(grd)
         self.adddims(withcf=withcf)
 
-    def addtime(self):
-        self.createDimension('TSTEP', 1).setunlimited(True)
+    def addtime(self, nsteps=1):
+        """
+        Adds TFLAG variable
+
+        Arguments
+        ---------
+        nsteps : int
+            Number of time steps to add
+
+        Returns
+        -------
+        None
+        """
+        self.createDimension('TSTEP', nsteps).setunlimited(True)
         self.createDimension('DATE-TIME', 2)
-        self.createDimension('VAR', 1)
-        self.NVARS = 1
-        tflag = self.createVariable(
-            'TFLAG', 'i',
-            ('TSTEP', 'VAR', 'DATE-TIME'),
-            units='<YYYYJJJ,HHMMSS>',
-            long_name='TFLAG'.ljust(16),
-            var_desc='TFLAG'.ljust(80)
-        )
-        tflag[:, :, 0] = self.SDATE
-        tflag[:, :, 1] = 0
+        self.NVARS = len(self._var_kwds)
+        self.createDimension('VAR', self.NVARS)
+        try:
+            self.updatetflag(overwrite=True)
+        except Exception as e:
+            warn(str(e))
+            tflag = self.createVariable(
+                'TFLAG', 'i',
+                ('TSTEP', 'VAR', 'DATE-TIME'),
+                units='<YYYYJJJ,HHMMSS>',
+                long_name='TFLAG'.ljust(16),
+                var_desc='TFLAG'.ljust(80)
+            )
+            tflag[:, :, 0] = self.SDATE
+            tflag[:, :, 1] = 0
 
     def adddims(self, withcf=True):
+        """
+        Add spatial dimensions
+
+        Arguments
+        ---------
+        withcf : bool
+            If true, add Climate and Forecasting convention variables
+
+        Returns
+        -------
+        None
+        """
         for k in 'LAY ROW COL PERIM'.split():
             if k in self.dimensions:
                 del self.dimensions[k]
@@ -163,12 +249,14 @@ class griddesc(ioapi_base):
                 'Only supports FTYPE 1 or 2; received ' +
                 str(self.FTYPE)
             )
-        self.createVariable(
-            'DUMMY', 'f', dims,
-            units='none'.ljust(16),
-            long_name='DUMMY'.ljust(16),
-            var_desc='DUMMY'.ljust(80)
-        )
+
+        for vark, varkw in self._var_kwds.items():
+            self.createVariable(
+                vark, 'f', dims,
+                long_name=vark.ljust(16),
+                var_desc=vark.ljust(80),
+                **varkw
+            )
 
         if self._synthvars is None:
             oldkeys = set(self.variables)

--- a/src/PseudoNetCDF/cmaqfiles/_ioapi.py
+++ b/src/PseudoNetCDF/cmaqfiles/_ioapi.py
@@ -238,7 +238,7 @@ Varable failures: {var_failed}
         PseudoNetCDFFile.setncatts(self, attdict)
         self._updatetime()
 
-    def createVariable(self, name, type, dimensions,
+    def createVariable(self, name, type='f', dimensions=None,
                        fill_value=None, **properties):
         """
         Wrapper on PseudoNetCDF.createVariable that updates VAR-LIST,
@@ -252,10 +252,19 @@ Varable failures: {var_failed}
         see PseudoNetCDFFile.createVariable
         """
         from copy import copy
+
+        ftype = getattr(self, 'FTYPE', 1)
+        hasperim = 'PERIM' in self.dimensions
+        if dimensions is None:
+            dimensions = ('TSTEP', 'LAY', 'ROW', 'COL')
+            if (ftype == 2) and hasperim:
+                dimensions = ('TSTEP', 'LAY', 'PERIM')
+
         properties = copy(properties)
         properties.setdefault('long_name', name.ljust(16))
         properties.setdefault('var_desc', name.ljust(80))
         properties.setdefault('units', 'unknown'.ljust(16))
+
         for pk, pv in list(properties.items()):
             if pk in ('long_name', 'units'):
                 properties[pk] = pv.ljust(16)
@@ -264,10 +273,13 @@ Varable failures: {var_failed}
 
         if name == 'TFLAG':
             fill_value = None
+
         out = PseudoNetCDFFile.createVariable(
             self, name=name, type=type, dimensions=dimensions,
             fill_value=fill_value, **properties)
+
         self._add2Varlist([name])
+
         return out
 
     def copy(self, props=True, dimensions=True, variables=True, data=True):

--- a/src/PseudoNetCDF/cmaqfiles/_ioapi.py
+++ b/src/PseudoNetCDF/cmaqfiles/_ioapi.py
@@ -62,6 +62,36 @@ class ioapi_base(PseudoNetCDFFile):
         super().__init__(self, *args, **kwds)
         self.setCoords(['TFLAG'])
 
+    def __setattr__(self, k, v):
+        """
+        IOAPI has expected data types, which largely conform to the NetCDF3
+        classic data model. For example, integers are int32 and floats are
+        float64. However, VGTOP and VGLVLS are exceptions where the data type
+        is expected to be float32. Further, any character variables will have
+        one of three lengths: 16, 80, 80 * 60.
+        """
+        if k == 'VGTOP':
+            v = np.float32(v)
+        elif k == 'VGLVLS':
+            v = np.asarray(v, dtype='f')
+        elif k in ('FILEDESC', 'HISTORY'):
+            if len(v) > 4800:
+                warn(f'Truncating {k} 4800')
+                v = v[:4800]
+            v = v.ljust(4800)
+        elif k in ('GDNAM', 'UPNAM'):
+            if len(v) > 16:
+                warn(f'Truncating {k} to 16')
+                v = v[:16]
+            v = v.ljust(16)
+        elif k in ('EXEC_ID',):
+            if len(v) > 80:
+                warn(f'Truncating {k} to 80')
+                v = v[:80]
+            v = v.ljust(80)
+
+        super().__setattr__(k, v)
+
     def audit_meta(self, fail='warn'):
         """
         Audit the IOAPI metadata. Checks existence of properties, dimensions
@@ -214,7 +244,8 @@ Varable failures: {var_failed}
         Wrapper on PseudoNetCDF.createVariable that updates VAR-LIST,
         NVARS, VAR, and TFLAG. Also adds long_name, var_desc, and units
         if not already in properties. long_name and var_desc default to
-        name, while units defaults to unknown
+        name, while units defaults to unknown. These properties will
+        also be adjusted to expected lengths (16, 80, 16).
 
         See also
         --------
@@ -225,6 +256,11 @@ Varable failures: {var_failed}
         properties.setdefault('long_name', name.ljust(16))
         properties.setdefault('var_desc', name.ljust(80))
         properties.setdefault('units', 'unknown'.ljust(16))
+        for pk, pv in list(properties.items()):
+            if pk in ('long_name', 'units'):
+                properties[pk] = pv.ljust(16)
+            elif pk in ('var_desc',):
+                properties[pk] = pv.ljust(80)
 
         if name == 'TFLAG':
             fill_value = None
@@ -261,17 +297,28 @@ Varable failures: {var_failed}
         --------
         see PseudoNetCDFFile.copyVariable
         """
-        outvar = PseudoNetCDFFile.copyVariable(
-            self, var, key=key, dtype=dtype, dimensions=dimensions,
-            fill_value=fill_value, withdata=withdata)
         if key is None:
-            for propk in ['name', 'standard_name', 'long_name']:
+            for propk in ['_name', 'name', 'standard_name', 'long_name']:
                 if hasattr(var, propk):
                     key = getattr(var, propk)
+                    break
             else:
                 raise AttributeError(
                     'varkey must be supplied because var has no name, ' +
                     'standard_name or long_name')
+
+        outvar = PseudoNetCDFFile.copyVariable(
+            self, var, key=key, dtype=dtype, dimensions=dimensions,
+            fill_value=fill_value, withdata=withdata)
+
+        # The long_name should be the same as the copied key
+        outvar.long_name = key.ljust(16)
+        # The var_desc and units should default to the copied variable
+        if not hasattr(outvar, 'var_desc'):
+            outvar.var_desc = key.ljust(80)
+        if not hasattr(outvar, 'units'):
+            outvar.units = 'unknown'.ljust(16)
+
         self._add2Varlist([key])
         return outvar
 

--- a/src/PseudoNetCDF/core/_files.py
+++ b/src/PseudoNetCDF/core/_files.py
@@ -2257,7 +2257,7 @@ class PseudoNetCDFFile(PseudoNetCDFSelfReg, object):
             copy of var in this file
         """
         if key is None:
-            for propk in ['name', 'standard_name', 'long_name']:
+            for propk in ['_name', 'name', 'standard_name', 'long_name']:
                 if hasattr(var, propk):
                     key = getattr(var, propk)
                     break


### PR DESCRIPTION
Allowing for files to be constructed from strings or io.StringIO
Allowing for cf variables to be disabled. Allowing properties
to be set at creation rather than overwritten latter.

See issue #122 