### PR TITLE
Fixing GDNAM in griddesc

### DIFF
--- a/src/PseudoNetCDF/cmaqfiles/_griddesc.py
+++ b/src/PseudoNetCDF/cmaqfiles/_griddesc.py
@@ -152,7 +152,7 @@ class griddesc(ioapi_base):
 
         self.setdefvars(var_kwds)
         self.addtime(nsteps)
-        self.setgrid(withcf=withcf)
+        self.setgrid(key=GDNAM, withcf=withcf)
         self.updatemeta()
         self.getVarlist()
 
@@ -207,6 +207,7 @@ class griddesc(ioapi_base):
             key = self.GDNAM.strip()
         grd = self._grd[key]
         prj = self._prj[grd['PRJNAME'].strip()]
+        self.setncattr('GDNAM', key)
         self.setncatts(prj)
         self.setncatts(grd)
         self.adddims(withcf=withcf)

--- a/src/PseudoNetCDF/test/test_cmaqfiles.py
+++ b/src/PseudoNetCDF/test/test_cmaqfiles.py
@@ -27,10 +27,21 @@ class griddesc(unittest.TestCase):
         with self.assertRaises(ValueError):
             griddesc(cmaqfiles_paths['griddesc'], FTYPE=3)
 
-    def testDefault(self):
+    def testDefaultGDNAM(self):
         from ..cmaqfiles import griddesc
         from ..testcase import cmaqfiles_paths
-        griddesc(cmaqfiles_paths['griddesc'])
+        f = griddesc(cmaqfiles_paths['griddesc'])
+        self.assertEqual(f.GDNAM.strip(), '12US1')
+
+    def testSpecificGDNAM(self):
+        from ..cmaqfiles import griddesc
+        from ..testcase import cmaqfiles_paths
+        f = griddesc(cmaqfiles_paths['griddesc'], GDNAM='12US1')
+        self.assertEqual(f.GDNAM.strip(), '12US1')
+        self.assertEqual(f.NCOLS, 459)
+        f = griddesc(cmaqfiles_paths['griddesc'], GDNAM='36US3')
+        self.assertEqual(f.GDNAM.strip(), '36US3')
+        self.assertEqual(f.NCOLS, 172)
 
     def testGridParams(self):
         from ..cmaqfiles import griddesc


### PR DESCRIPTION
The default grid name was working, but the specific was not. This was unexpected and not fully tested. I have fixed the bug and added a test to prevent recursion.