### PR TITLE
Bugfix/griddesc commas

### DIFF
--- a/src/PseudoNetCDF/_getreader.py
+++ b/src/PseudoNetCDF/_getreader.py
@@ -82,24 +82,25 @@ def registerreader(name, reader):
         return False
 
 
-def pncmfopen(*args, stackdim=None, **kwds):
+def pncmfopen(paths, *args, stackdim=None, **kwds):
     """Open any PNC supported format using pncopen on all files
     passed as teh first argument of pncmfopen. See pncopen
 
     Parameters
     ----------
+    paths : list
+        List of paths to open
     args : arguments
-        args[0] must be a list of paths, other arguments are format specific
+        pncopen arguments (see pncopen)
     stackdim : str
         dimension upon which to stack files
     kwds : dict
-        see pncopen for more details
+        pncopen and format-specific keywords (see pncopen for more details)
 
     Returns
     -------
     pfile : PseudoNetCDF
     """
-    paths = args[0]
     files = [pncopen(path, *args[1:], **kwds) for path in paths]
     file1 = files[0]
     return file1.stack(files[1:], stackdim=stackdim)
@@ -121,7 +122,8 @@ def pncopen(*args, **kwds):
     addcf : boolean
         to add CF conventions (not passed to reader; default: False)
     diskless : boolean
-        to add CF conventions (not passed to reader; default: False)
+        If addcf (default: False), the file must either be wrapped or loaded
+        into memory (diskless) to add attributes.
     help : boolean
         without format, returns help of pncopen and with format keyword,
         returns help of that class. See the __init__ interface for help

--- a/src/PseudoNetCDF/camxfiles/FortranFileUtil.py
+++ b/src/PseudoNetCDF/camxfiles/FortranFileUtil.py
@@ -320,7 +320,7 @@ def OpenRecordFile(rf):
 
     rf - str, unicode, file, RecordFile
     """
-    if type(rf) == RecordFile:
+    if isinstance(rf, RecordFile):
         pass
     else:
         rf = RecordFile(rf)

--- a/src/PseudoNetCDF/camxfiles/uamiv/Transforms.py
+++ b/src/PseudoNetCDF/camxfiles/uamiv/Transforms.py
@@ -59,10 +59,10 @@ class osat(PseudoNetCDFFile):
         self.__regionsbyNm[''] = tuple(self.__regionsbyNm.keys())
 
         for k, v in sources.items():
-            if type(v) == str:
+            if isinstance(v, str):
                 sources[k] = (v,)
         for k, v in regions.items():
-            if type(v) == str:
+            if isinstance(v, str):
                 regions[k] = (v,)
 
         # Update with user supplied keys

--- a/src/PseudoNetCDF/camxfiles/wind/Read.py
+++ b/src/PseudoNetCDF/camxfiles/wind/Read.py
@@ -299,10 +299,10 @@ class wind(PseudoNetCDFFile):
     __iter__ = keys
 
     def getArray(self, krange=slice(1, None)):
-        if type(krange) != slice:
-            if type(krange) == tuple:
+        if isinstance(krange, slice):
+            if isinstance(krange, tuple):
                 krange = slice(*krange)
-            if type(krange) == int:
+            if isinstance(krange, int):
                 krange = slice(krange, krange + 1)
         a = zeros(
             (

--- a/src/PseudoNetCDF/geoschemfiles/_gcnc.py
+++ b/src/PseudoNetCDF/geoschemfiles/_gcnc.py
@@ -73,7 +73,7 @@ class gcnc_base(PseudoNetCDFFile):
             nout = outb.sum()
             if nout > 0:
                 message = '{} Points out of bounds {:.1%}; {}'.format(
-                    nout, nout/i.size, np.where(outb))
+                    nout, nout / i.size, np.where(outb))
                 if bounds == 'error':
                     raise ValueError(message)
                 else:

--- a/src/PseudoNetCDF/net_balance.py
+++ b/src/PseudoNetCDF/net_balance.py
@@ -32,7 +32,7 @@ class sum_reader(pncf):
         return False
 
     def __init__(self, sumfile):
-        if type(sumfile) == str:
+        if isinstance(sumfile, str):
             self.sumfile = open(sumfile, 'r')
         else:
             self.sumfile = sumfile
@@ -88,9 +88,10 @@ def net_reaction(net_rxns, net_rxn, time='Daily'):
         elif v < 0:
             reactants.extend((-1 * v, spc))
 
-    return ((" + ".join([tmp for i in reactants if type(i) == str]) + " <-> " +
-             " + ".join([tmp for i in products if type(i) == str])) %
-            tuple(reactants + products))
+    return ((
+        " + ".join([tmp for i in reactants if isinstance(i, str)]) + " <-> "
+        + " + ".join([tmp for i in products if isinstance(i, str)])
+    ) % tuple(reactants + products))
 
 
 class ctb_reader(pncf):
@@ -99,7 +100,7 @@ class ctb_reader(pncf):
         return False
 
     def __init__(self, file):
-        if type(file) == str:
+        if isinstance(file, str):
             file = open(file)
         lines = file.readlines()
         parameters, daily, peak = self.parse(lines)
@@ -135,7 +136,7 @@ class net_reader(pncf):
         self.nrxns = []
         self.time = []
 
-        if type(infile) == str:
+        if isinstance(infile, str):
             infile = open(infile)
         lines = infile.readlines()
         self.parse(lines, False)

--- a/src/PseudoNetCDF/units.py
+++ b/src/PseudoNetCDF/units.py
@@ -123,7 +123,7 @@ class converters_dict(defaultdict):
             self[k] = v
 
     def __missing__(self, key):
-        if type(key) == tuple and key[0] == key[1]:
+        if isinstance(key, tuple) and key[0] == key[1]:
             return lambda a: a
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py36
+envlist = py39
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed


### PR DESCRIPTION
* Adding robust GRIDDESC
  * Allows ! prefixed comments
  * Allows commas instead of spaces
  * Allows doubles written with D or d
* Addition projection support for testing IOAPI docs example griddesc.
  * Added standard mercator, transverse mercator, and UTM.
  * Still need ALBGRID3 (9), LEQGRD3 (10) and SINUGRD3 (11)
  * Note that all cases where there are two decimals in the example file need to be fixed. (fails with m3fake too)
* Miscellaneous should have been their own PR
  * Updating tox environment to python 3.9
  * Fixing flake error from gcnc
  * Fixing flake8 compliance by replacing type(x) == class with isinstance(x, class)
  * Fixing documentation for pncopen and pncmfopen