### PR TITLE
audit bcon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ extra_requires_dict = {
 
 setup(
     name='PseudoNetCDF',
-    version='3.3.1',
+    version='3.3.2',
     author='Barron Henderson',
     author_email='barronh@gmail.com',
     maintainer='Barron Henderson',

--- a/src/PseudoNetCDF/cmaqfiles/_ioapi.py
+++ b/src/PseudoNetCDF/cmaqfiles/_ioapi.py
@@ -190,7 +190,7 @@ class ioapi_base(PseudoNetCDFFile):
             if dk in ('TSTEP', 'DATE-TIME', 'PERIM'):
                 continue
             audit[f'has_N{dk}S'] = hasattr(self, f'N{dk}S')
-            if audit[f'has_N{dk}S']:
+            if audit[f'has_N{dk}S'] and dk in dimlens:
                 audit[dk] = getattr(self, f'N{dk}S', 0) == dimlens[dk]
 
         if audit['has_ROW'] and audit['has_COL'] and not audit['has_PERIM']:


### PR DESCRIPTION
Currently fails when NCOLS and NROWS exist, but COL and ROW dimensions do not. This occurs for boundary files that have dimensions TSTEP, VAR, DATE-TIME, and PERIM. This fix will audit BCON files by only comparing NROWS and NCOLS to dimensions if they exist.