### PR TITLE
fix: preserve masked variable metadata in __array_finalize__ (rebased)

### DIFF
--- a/src/PseudoNetCDF/core/_variables.py
+++ b/src/PseudoNetCDF/core/_variables.py
@@ -347,6 +347,7 @@ class PseudoNetCDFMaskedVariable(PseudoNetCDFVariable, np.ma.MaskedArray):
 
     def __array_finalize__(self, obj):
         np.ma.MaskedArray.__array_finalize__(self, obj)
+        PseudoNetCDFVariable.__array_finalize__(self, obj)
 
     def _update_from(self, obj):
         dt = self.dtype.char

--- a/src/PseudoNetCDF/test/test_core.py
+++ b/src/PseudoNetCDF/test/test_core.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 from PseudoNetCDF import PseudoNetCDFFile, PseudoNetCDFVariables
 from PseudoNetCDF import PseudoNetCDFVariable, pncopen
+from PseudoNetCDF.core._variables import PseudoNetCDFMaskedVariable
 from . import requires_basemap, requires_pyproj, requires_matplotlib
 from . import compare_files
 from PseudoNetCDF.pncwarn import warn
@@ -59,6 +60,24 @@ class PseudoNetCDFVariableTest(unittest.TestCase):
         viewed = var.view(PseudoNetCDFVariable)
         refdims = tuple([f'phony_dim_{i}' for i in range(ta.ndim)])
         assert (viewed.dimensions == refdims)
+
+    def testMaskedArrayFinalizeCopiesPseudoNetCDFMetadata(self):
+        parent = PseudoNetCDFFile()
+        parent.createDimension('y', 1)
+        parent.createDimension('x', 5)
+        masked = np.ma.array(self.myarray[:1], mask=[[0, 1, 0, 1, 0]])
+        var = PseudoNetCDFMaskedVariable(
+            parent, 'unknown', 'f', ('y', 'x'),
+            values=masked, units='unknown', long_name='masked variable'
+        )
+
+        copied = var.copy()
+
+        assert (copied.dimensions == ('y', 'x'))
+        assert (copied.getncatts() == {
+            'units': 'unknown', 'long_name': 'masked variable',
+        })
+        np.testing.assert_array_equal(copied.mask, masked.mask)
 
 
 class PseudoNetCDFFileTest(unittest.TestCase):


### PR DESCRIPTION
Rebased version of #159 with merge conflict resolved.

This PR preserves masked variable metadata (dimensions, attributes, mask) when using  for view/copy operations.

The conflict in test_core.py was resolved by keeping both:
- Upstream's  
- This PR's 

Both tests now pass.